### PR TITLE
Enhance sync endpoint and timeout settings for async cutouts

### DIFF
--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -20,7 +20,7 @@ GUNICORN_CMD="gunicorn config.wsgi:application \
     --bind 0.0.0.0:8000 \
     --workers ${GUNICORN_WORKERS:-2} \
     --threads ${GUNICORN_THREADS:-2} \
-    --timeout 180"
+    --timeout 300"
 
 # Adiciona --reload se GUNICORN_RELOAD for true/1/True
 if [ "${GUNICORN_RELOAD}" = "1" ] || [ "${GUNICORN_RELOAD}" = "true" ] || [ "${GUNICORN_RELOAD}" = "True" ]; then

--- a/compose/production/traefik/traefik.yml
+++ b/compose/production/traefik/traefik.yml
@@ -14,6 +14,12 @@ entryPoints:
   web-secure:
     # https
     address: ':443'
+    # Allow long-running sync cutouts / mosaics (default readTimeout is 60s).
+    transport:
+      respondingTimeouts:
+        readTimeout: 300s
+        writeTimeout: 300s
+        idleTimeout: 300s
 
   flower:
     address: ':5555'
@@ -67,9 +73,17 @@ http:
       headers:
         hostsProxyHeaders: ['X-CSRFToken']
 
+  serversTransports:
+    django-transport:
+      forwardingTimeouts:
+        dialTimeout: 30s
+        responseHeaderTimeout: 300s
+        idleConnTimeout: 300s
+
   services:
     django:
       loadBalancer:
+        serversTransport: django-transport
         servers:
           - url: http://django:5000
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -354,11 +354,10 @@ CELERY_TASK_SERIALIZER = "json"
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-result_serializer
 CELERY_RESULT_SERIALIZER = "json"
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-time-limit
-# TODO: set to whatever value is adequate in your circumstances
-CELERY_TASK_TIME_LIMIT = 5 * 60
+# Hard kill after soft limit; sized for 15' / multi-band async cutouts.
+CELERY_TASK_TIME_LIMIT = 15 * 60
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-soft-time-limit
-# TODO: set to whatever value is adequate in your circumstances
-CELERY_TASK_SOFT_TIME_LIMIT = 60
+CELERY_TASK_SOFT_TIME_LIMIT = 10 * 60
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#beat-scheduler
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-send-task-events

--- a/cutout/service/api/views.py
+++ b/cutout/service/api/views.py
@@ -27,9 +27,9 @@ from .serializers import (
     JobResultSerializer,
 )
 
-# Cutouts with radius >= 10 arcmin must use the async endpoint.
+# Cutouts with radius > 10 arcmin must use the async endpoint.
 # Sync processing would take 60s+ and hit gateway/proxy timeouts.
-_SYNC_RADIUS_LIMIT_DEG = 0.166667  # 10 arcmin in degrees
+_SYNC_RADIUS_LIMIT_DEG = 10 / 60  # 10 arcmin in degrees
 _SYNC_RADIUS_MESSAGE = (
     "Cutout radius {radius:.1f} arcmin exceeds the synchronous limit "
     "of 10 arcmin. Please use POST /api/async instead. "
@@ -223,12 +223,13 @@ class SyncCutoutView(APIView):
         if radius_deg is None:
             return
 
-        if radius_deg >= _SYNC_RADIUS_LIMIT_DEG:
-            radius_arcmin = radius_deg * 60
+        radius_arcmin = radius_deg * 60
+        # Compare in arcmin at 0.1' precision so 0.166667° (≈10') is accepted.
+        if round(radius_arcmin, 1) > 10:
             # Rough estimate: FITS ~radius², PNG ~3x
             is_png = task.output_format == "png"
             is_color = any(p.parameter_id == "color" and str(p.value).lower() == "true" for p in params)
-            base_seconds = (radius_deg / 0.166667) ** 2 * 25
+            base_seconds = (radius_deg / _SYNC_RADIUS_LIMIT_DEG) ** 2 * 25
             estimated = int(base_seconds * (3 if (is_png and is_color) else 1))
             raise ParameterError(_SYNC_RADIUS_MESSAGE.format(radius=radius_arcmin, estimated=estimated))
 

--- a/cutout/service/tests/test_sync_api.py
+++ b/cutout/service/tests/test_sync_api.py
@@ -139,26 +139,42 @@ def test_sync_get_rejects_multiple_tasks(user, monkeypatch, tmp_path):
 
 @pytest.mark.django_db(transaction=True)
 def test_sync_get_rejects_large_radius(user, monkeypatch, tmp_path):
-    """Radii >= 10 arcmin must use async — sync returns 422 with guidance."""
+    """Radii > 10 arcmin must use async — sync returns 422 with guidance."""
     _patch_async_result_path(monkeypatch, tmp_path)
     _patch_cutout_execution(monkeypatch, tmp_path)
 
     response = _client(user).get(
         reverse("api:sync_cutout"),
-        {"id": "des_dr2", "pos": "CIRCLE 0.5 2.15 0.166667", "band": "r", "format": "fits"},
+        {"id": "des_dr2", "pos": "CIRCLE 0.5 2.15 0.25", "band": "r", "format": "fits"},
     )
 
     assert response.status_code == 422
     detail = response.json()["detail"]
     assert "exceeds the synchronous limit" in detail
     assert "POST /api/async" in detail
-    assert "10.0 arcmin" in detail
+    assert "10 arcmin" in detail
 
     job = Job.objects.get()
     assert job.phase == Job.ExecutionPhase.ERROR
     task = job.tasks.get()
     assert task.status == Task.Status.ERROR
     assert "exceeds the synchronous limit" in task.error_message
+
+
+@pytest.mark.django_db(transaction=True)
+def test_sync_get_allows_exact_10_arcmin(user, monkeypatch, tmp_path):
+    """Radii exactly at the 10 arcmin sync limit are accepted."""
+    _patch_async_result_path(monkeypatch, tmp_path)
+    _patch_cutout_execution(monkeypatch, tmp_path)
+
+    response = _client(user).get(
+        reverse("api:sync_cutout"),
+        {"id": "des_dr2", "pos": "CIRCLE 0.5 2.15 0.16666666666666666", "band": "r", "format": "fits"},
+    )
+
+    assert response.status_code == 200
+    job = Job.objects.get()
+    assert job.phase == Job.ExecutionPhase.COMPLETED
 
 
 @pytest.mark.django_db(transaction=True)

--- a/cutout/templates/base.html
+++ b/cutout/templates/base.html
@@ -15,6 +15,16 @@
     <meta name="description" content="LIneA Cutout Service" />
     <meta name="author" content="Daniel Roy Greenfeld" />
     <link rel="icon" href="{% static 'images/favicons/favicon.ico' %}" />
+    {% if not debug %}
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-MZYMGVE78K"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-MZYMGVE78K');
+    </script>
+    {% endif %}
     {% block css %}
       <!-- Latest compiled and minified Bootstrap CSS -->
       <link rel="stylesheet"


### PR DESCRIPTION
This pull request increases the allowed duration for long-running cutout tasks and refines the logic for synchronous cutout radius limits. It also introduces improvements to proxy and worker timeouts to better support these longer operations, and adds a Google Analytics tag to the production site. The most important changes are summarized below:

**Timeout and Task Duration Increases:**
* Increased Gunicorn timeout from 180 to 300 seconds in `compose/production/django/start` to allow longer-running HTTP requests.
* Increased Celery task time limits in `config/settings/base.py` (`CELERY_TASK_TIME_LIMIT` to 15 minutes and `CELERY_TASK_SOFT_TIME_LIMIT` to 10 minutes) to support longer asynchronous cutout operations.

**Proxy and Server Configuration:**
* Updated Traefik configuration in `compose/production/traefik/traefik.yml` to set `readTimeout`, `writeTimeout`, and `idleTimeout` to 300 seconds for the secure web entrypoint, and configured a custom `serversTransport` with extended timeouts for the Django service. [[1]](diffhunk://#diff-3b94e3a38f2408dd629032dcbe1f9e3872bb5ee15c56ac8aceb9998e4130a2ffR17-R22) [[2]](diffhunk://#diff-3b94e3a38f2408dd629032dcbe1f9e3872bb5ee15c56ac8aceb9998e4130a2ffR76-R86)

**Cutout Radius Limit Logic:**
* Refined the synchronous cutout endpoint to allow requests with a radius exactly equal to 10 arcmin, rejecting only those greater than 10 arcmin, and improved the precision of the comparison logic in `cutout/service/api/views.py`. [[1]](diffhunk://#diff-db25004e843e6cb5d3d424c607950e33b8f576152b92b99c1bb7c8db177cf91dL30-R32) [[2]](diffhunk://#diff-db25004e843e6cb5d3d424c607950e33b8f576152b92b99c1bb7c8db177cf91dL226-R232)

**Testing:**
* Updated and added tests in `cutout/service/tests/test_sync_api.py` to verify that radii > 10 arcmin are rejected and exactly 10 arcmin are accepted by the synchronous API. [[1]](diffhunk://#diff-6dbca15e7149e77bf8cbfc0a4dcaef035730af61fe8db99a42c24d03b4a9481fL142-R155) [[2]](diffhunk://#diff-6dbca15e7149e77bf8cbfc0a4dcaef035730af61fe8db99a42c24d03b4a9481fR164-R179)

**Analytics:**
* Added Google Analytics tracking code to `cutout/templates/base.html`, enabled only in non-debug (production) mode.